### PR TITLE
Activacion del Menu de Estratagemas

### DIFF
--- a/src/services/keyboard-simulator/keyboard-simulator.ts
+++ b/src/services/keyboard-simulator/keyboard-simulator.ts
@@ -19,7 +19,7 @@ export default class KeyboardSimulator {
     const { keysCode } = stratagem;
 
     let pressKey = "";
-
+    this.simulateHoldAtivationStratagem(true);
     keysCode.forEach((key: string) => {
       switch (key) {
         case "up":
@@ -50,9 +50,15 @@ export default class KeyboardSimulator {
         );
       }
     });
+    this.simulateHoldAtivationStratagem(false);
   }
 
   private simulateKeyOnKeyboard(key: string) {
     robot.keyTap(key);
+  }
+
+  private simulateHoldAtivationStratagem(active: boolean) {
+    console.log("KeyBoardSimulator.simulateHoldAtivationStratagem");
+    robot.keyToggle("control", active ? "down" : "up");
   }
 }

--- a/src/services/keyboard-simulator/keyboard-simulator.ts
+++ b/src/services/keyboard-simulator/keyboard-simulator.ts
@@ -57,6 +57,11 @@ export default class KeyboardSimulator {
     robot.keyTap(key);
   }
 
+  /**
+   * Allows to simulate the hold activation of the stratagem menu.
+   * @param active 
+   * 
+   */
   private simulateHoldAtivationStratagem(active: boolean) {
     console.log("KeyBoardSimulator.simulateHoldAtivationStratagem");
     robot.keyToggle("control", active ? "down" : "up");


### PR DESCRIPTION
Este cambio permite que al selecionar una estratagema, esta en vez que el usuario abra el menu, ahora se abre de manera automatica y se cierra, incluso al seleccionar otra estratagema esta se cambia